### PR TITLE
Changed HashSet lib to LinkedHashSet due to the method getFirstSequence

### DIFF
--- a/src/main/org/htw/prog2/aufgabe1/SeqFile.java
+++ b/src/main/org/htw/prog2/aufgabe1/SeqFile.java
@@ -1,6 +1,6 @@
 package org.htw.prog2.aufgabe1;
 
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 
 public class SeqFile {
     /**
@@ -23,7 +23,7 @@ public class SeqFile {
      *
      * @return The sequences read from the FASTA file, or an empty HashSet is isValid() is false.
      */
-    public HashSet<String> getSequences() {
+    public LinkedHashSet<String> getSequences() {
         return null;
     }
 


### PR DESCRIPTION
It requires a maintained insertion order for its functionality, which HashSet cannot provide. 
So instead of importing an additional data structure like ArrayList and converting that into a HashSet it is much more efficient to just use a LinkedHashSet which keeps a linked list next to the hashtable internally to maintain the insertion order.